### PR TITLE
feat: allow resources to have directory structure

### DIFF
--- a/src/Distribution/AppImage.hs
+++ b/src/Distribution/AppImage.hs
@@ -44,7 +44,10 @@ data AppImage = AppImage {
   -- | Application icons.
   appIcons        :: [FilePath],
   -- | Other resources to bundle. Stored in the @\usr\/share\//appName/@
-  -- directory inside the image.
+  -- directory inside the image. The first 'FilePath' is on the local system.
+  -- The @Maybe 'FilePath'@ is the desired file path relative to
+  -- @\usr\/share\//appName/@, or the directoryless filename in the case of
+  -- 'Nothing'.
   appResources    :: [(FilePath, Maybe FilePath)],
   -- | Hook to customize the generated @AppDir@ before final packaging.
   appDirCustomize :: Maybe AppDirCustomize

--- a/src/Distribution/AppImage.hs
+++ b/src/Distribution/AppImage.hs
@@ -45,7 +45,7 @@ data AppImage = AppImage {
   appIcons        :: [FilePath],
   -- | Other resources to bundle. Stored in the @\usr\/share\//appName/@
   -- directory inside the image.
-  appResources    :: [(FilePath, FilePath)],
+  appResources    :: [(FilePath, Maybe FilePath)],
   -- | Hook to customize the generated @AppDir@ before final packaging.
   appDirCustomize :: Maybe AppDirCustomize
   }
@@ -100,13 +100,13 @@ deployExe exe AppImage{..} appDir verb = do
     , "--desktop-file=" ++ appDesktop ] ++
     map ("--icon-file=" ++) appIcons
 
-bundleFiles :: [(FilePath, FilePath)] -> FilePath -> Verbosity -> IO ()
+bundleFiles :: [(FilePath, Maybe FilePath)] -> FilePath -> Verbosity -> IO ()
 bundleFiles files dest verb = prepare >> mapM_ (uncurry copy) files
   where
     prepare = createDirectoryIfMissingVerbose verb True dest
 
     copy file destfile = do
-      let fp = dest </> destfile
+      let fp = dest </> fromMaybe (takeFileName file) destfile
       createDirectoryIfMissingVerbose verb True $ takeDirectory fp
       copyFileVerbose verb file fp
 


### PR DESCRIPTION
I'm working on a game and would like my game assets to retain their directory structure; this PR lets me give a filepath for every resource.